### PR TITLE
Support HTTP response without Content-Type header

### DIFF
--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -153,7 +153,7 @@ export class Fetcher extends EventEmitter {
 
         // in plain/text, res.text is body but
         // in application/json, res.body is parsed json
-        if (header['content-type'].match(/application\/json/)) {
+        if (header['content-type'] && header['content-type'].match(/application\/json/)) {
           body = res.body;
         }
 


### PR DESCRIPTION
Crashed when server returns response without Content-Type header.

Some server implementation returns response without Content-Type header for result of HTTP DELETE method.
